### PR TITLE
AI Updates & Player Enhancements

### DIFF
--- a/Assets/lcars-banner.svg
+++ b/Assets/lcars-banner.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 260" width="900" height="260" role="img" aria-label="LCARS47 — Planetary Dynamics Discord Bot">
+  <title>LCARS47 — Planetary Dynamics Discord Bot</title>
+
+  <!-- Console backdrop -->
+  <rect x="0" y="0" width="900" height="260" rx="18" fill="#000000"/>
+
+  <!-- LCARS elbow (top bar + left sidebar joined by a rounded corner) -->
+  <path d="M 24,150 L 24,88 Q 24,24 88,24 L 300,24 L 300,88 L 116,88 Q 88,88 88,116 L 88,150 Z" fill="#FF9966"/>
+
+  <!-- Left sidebar segments -->
+  <rect x="24" y="156" width="64" height="40" rx="4" fill="#CC99CC"/>
+  <rect x="24" y="202" width="64" height="34" rx="4" fill="#9999FF"/>
+
+  <!-- Top bar segments to the right of the elbow -->
+  <rect x="308" y="24" width="150" height="64" rx="4" fill="#FFCC66"/>
+  <rect x="466" y="24" width="96"  height="64" rx="4" fill="#CC99CC"/>
+  <rect x="570" y="24" width="190" height="64" rx="4" fill="#9999FF"/>
+  <rect x="768" y="24" width="108" height="64" rx="4" fill="#CC6666"/>
+
+  <!-- Title block -->
+  <text x="120" y="186" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="86" letter-spacing="8" fill="#FF9966">LCARS 47</text>
+  <text x="124" y="222" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="16" letter-spacing="4" fill="#FFCC66">LIBRARY COMPUTER ACCESS / RETRIEVAL SYSTEM</text>
+
+  <!-- Decorative readout tags (stacked, right-aligned, clear of the subtitle) -->
+  <text x="876" y="132" text-anchor="end" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="18" letter-spacing="3" fill="#9999FF">UNIT 47 · PLDYN</text>
+  <text x="876" y="164" text-anchor="end" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="18" letter-spacing="3" fill="#CC99CC">SYS · ONLINE · 47-A</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# LCARS47
-The official Planetary Dynamics Discord Bot
+<div align="center">
 
---
+![LCARS47 — Planetary Dynamics Discord Bot](Assets/lcars-banner.svg)
+
+**The official Planetary Dynamics Discord Bot**
+
+![Version](https://img.shields.io/github/package-json/v/SkyeRangerDelta/LCARS47?style=for-the-badge&label=VERSION&labelColor=000000&color=FF9966)
+![Status](https://img.shields.io/badge/STATUS-ONLINE-9999FF?style=for-the-badge&labelColor=000000)
+![License](https://img.shields.io/badge/LICENSE-SOURCE_AVAILABLE-CC99CC?style=for-the-badge&labelColor=000000)
+![Unit](https://img.shields.io/badge/UNIT-47-FFCC66?style=for-the-badge&labelColor=000000)
 
 [![Pldyn Official Repo](https://img.shields.io/badge/PlDyn-Official%20Repo-2d6ded)](https://pldyn.net)
 [![Node.js CI](https://github.com/SkyeRangerDelta/LCARS47/actions/workflows/test.yml/badge.svg)](https://github.com/SkyeRangerDelta/LCARS47/actions/workflows/dev-test.yml)
@@ -9,36 +15,51 @@ The official Planetary Dynamics Discord Bot
 [![semantic-release: ESLint](https://img.shields.io/badge/semantic--release-eslint-341bab?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 ![GitHub top language](https://img.shields.io/github/languages/top/skyerangerdelta/LCARS47)
 
+</div>
+
 Developed and Maintained by: SkyeRangerDelta
 
 Developed for use in the Planetary Dynamics (PlDyn) Discord server by PlDyn members for their use.
 
-## Features
-- Music player capabilities
-    - Search/direct link (`/play`)
-    - Queue / Now Playing / Skip / Stop
-    - Jellyfin library preferred over YouTube (`/play`, `/jellyfin-search`)
-    - In-place yt-dlp binary refresh (`/ytdlp-update`)
-- System status / API
-- James Webb Space Telescope (JWST)
-- Discord Role Controls
+---
 
-## Media Player
+> `LCARS47 ONLINE.` Library Computer Access/Retrieval System, unit 47. Standing by.
 
-| Provider | Source | Notes |
-|---|---|---|
-| Jellyfin | `@jellyfin/sdk` catalog | Tried first when configured. Reads `Item.Path` and streams the file from the NAS directly; falls back to Jellyfin HTTP audio stream if the path isn't reachable. |
-| YouTube  | `youtube-sr` + `ytdlp-nodejs` | Fallback when nothing matches in the library. The yt-dlp binary lives at `/usr/local/bin/yt-dlp` in the container and is refreshed in place by `/ytdlp-update`. |
+**LCARS47** is the resident ship's computer for the Planetary Dynamics Discord — a Star Trek
+/ Warhammer 40K–flavored bot, purpose-built and operated for PlDyn.
 
+---
 
-## Mechanics
-LCARS47 is a TypeScript application and runs under the Discord.JS API. The system structure primarily runs in the following order:
-1. Initialize
-   1. Register event logic
-   2. Register individual command logic
-   3. Register guild slash commands
-2. Login
-3. Listen for events
-   1. Event handler -> command handler (no other events significantly processed)
-      1. Command handler processes/does things
-   2. RDS (Remote Data Store) transactions recorded per event
+![AUDIO OPERATIONS](https://img.shields.io/badge/AUDIO_OPERATIONS-FF9966?style=for-the-badge&labelColor=FF9966)
+
+A full voice-channel music system. It streams from a private Jellyfin library first and the
+open web second, handling search, queueing, whole albums and playlists, an interactive song
+selector, now-playing readouts with cover art, and on-demand lyrics.
+
+![COMPUTER AI](https://img.shields.io/badge/COMPUTER_AI-CC99CC?style=for-the-badge&labelColor=CC99CC)
+
+An in-character ship's computer powered by Claude. It converses through several distinct
+personas, reasons over attached images and documents, can think harder when asked, and reaches
+into the bot's own systems so its answers reflect what's actually happening aboard.
+
+![OPERATIONS](https://img.shields.io/badge/OPERATIONS-9999FF?style=for-the-badge&labelColor=9999FF)
+
+Real-time health and status for the crew's infrastructure — load, memory, storage, and uptime
+across monitored hosts — alongside the bot's own vitals and a properly computed stardate.
+
+![STELLAR CARTOGRAPHY](https://img.shields.io/badge/STELLAR_CARTOGRAPHY-FFCC66?style=for-the-badge&labelColor=FFCC66)
+
+Imagery pulled straight from the James Webb Space Telescope archive — nebulae, galaxy
+clusters, and exoplanet observations on request.
+
+![CREW SERVICES](https://img.shields.io/badge/CREW_SERVICES-CC6666?style=for-the-badge&labelColor=CC6666)
+
+Self-serve role management plus a Ferengi Dabo wheel for wagering Gold-Pressed Latinum —
+balances, streaks, and leaderboards included.
+
+---
+
+**Source-available.** Read it, study it, reference it, and open issues or pull requests —
+you're welcome to. LCARS47 is built specifically for the Planetary Dynamics server and isn't
+packaged for general use; if you work out what it takes to self-host, you're free to try, but
+no setup help or support will be provided. © SkyeRangerDelta.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The official Planetary Dynamics Discord Bot
 
 Developed and Maintained by: SkyeRangerDelta
 
-For use only in the Planetary Dynamics(PlDyn) Discord server by PlDyn members for their use.
+Developed for use in the Planetary Dynamics (PlDyn) Discord server by PlDyn members for their use.
 
 ## Features
 - Music player capabilities
@@ -25,29 +25,11 @@ For use only in the Planetary Dynamics(PlDyn) Discord server by PlDyn members fo
 
 ## Media Player
 
-The player is provider-abstracted (`Src/Subsystems/MediaPlayer/`):
-
 | Provider | Source | Notes |
 |---|---|---|
 | Jellyfin | `@jellyfin/sdk` catalog | Tried first when configured. Reads `Item.Path` and streams the file from the NAS directly; falls back to Jellyfin HTTP audio stream if the path isn't reachable. |
 | YouTube  | `youtube-sr` + `ytdlp-nodejs` | Fallback when nothing matches in the library. The yt-dlp binary lives at `/usr/local/bin/yt-dlp` in the container and is refreshed in place by `/ytdlp-update`. |
 
-### Required env for Jellyfin
-
-```
-JELLYFIN_HOST=jellyfin.example.lan
-JELLYFIN_PORT=8096
-JELLYFIN_USER=lcars
-JELLYFIN_PASS=...
-JELLYFIN_KEY=...           # optional API key (used as initial token)
-JELLYFIN_PATH_MAP=/media/music=>/mnt/nas/music,/media/abk=>/mnt/nas/abk
-```
-
-`JELLYFIN_PATH_MAP` translates the **Jellyfin server's** view of a file path to the path that path appears at **inside the bot container**. If the bot can't see the file at the translated path it transparently falls back to Jellyfin's HTTP stream. Without the map (or without the NAS mounted in the container) every Jellyfin track plays via HTTP — still works, just transcoded by the Jellyfin server.
-
-### Admin
-
-`/ytdlp-update` refreshes the yt-dlp binary in place — use when YouTube playback starts failing with extraction errors. Restricted by Discord guild Administrator permission. Add `ADMIN_USER_IDS=<id1>,<id2>` for an additional allow-list.
 
 ## Mechanics
 LCARS47 is a TypeScript application and runs under the Discord.JS API. The system structure primarily runs in the following order:

--- a/Src/Commands/Active/lyrics.ts
+++ b/Src/Commands/Active/lyrics.ts
@@ -1,0 +1,170 @@
+// -- LYRICS --
+// Displays lyrics for the currently-playing track. Sources lyrics from the
+// Jellyfin library first (when the track is a Jellyfin item with an .lrc /
+// embedded lyric), and falls back to lrclib.net for everything else (YouTube
+// tracks, or library tracks with no stored lyrics). Renders as static text,
+// paginated across follow-up messages to respect Discord's 2000-char limit.
+
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { type LCARSClient } from '../../Subsystems/Auxiliary/LCARSClient.js';
+import {
+  type AutocompleteInteraction,
+  type ChatInputCommandInteraction,
+  type GuildMember,
+  type InteractionResponse,
+  MessageFlags
+} from 'discord.js';
+import Utility from '../../Subsystems/Utilities/SysUtils.js';
+import { type Command } from '../../Subsystems/Auxiliary/Interfaces/CommandInterface';
+import { JellyfinProvider } from '../../Subsystems/MediaPlayer/Providers/JellyfinProvider.js';
+import LrcLibClient from '../../Subsystems/Lyrics/LrcLibClient.js';
+import { type LyricsResult } from '../../Subsystems/Jellyfin/Interfaces/LyricLine.js';
+import { type Track } from '../../Subsystems/MediaPlayer/Interfaces/Track.js';
+
+// Leave headroom under Discord's 2000-char limit for the page header.
+const CHUNK_BUDGET = 1900;
+
+const data = new SlashCommandBuilder()
+  .setName( 'lyrics' )
+  .setDescription( 'Shows the lyrics for the currently playing song.' );
+
+async function execute (
+  LCARS47: LCARSClient,
+  int: ChatInputCommandInteraction | AutocompleteInteraction
+): Promise<InteractionResponse | void> {
+  if ( int.isAutocomplete() ) return await int.respond([
+    { name: 'This command does not support autocomplete.', value: 'none' }
+  ]);
+
+  Utility.log( 'info', '[MEDIA-PLAYER] Received a lyrics request.' );
+
+  let member: GuildMember;
+  try {
+    member = await LCARS47.PLDYN.members.fetch( int.user.id );
+  }
+  catch {
+    return await int.reply( {
+      content: 'No data could be found on your user. Process terminated.',
+      flags: MessageFlags.Ephemeral
+    } );
+  }
+
+  if ( member.voice?.channel == null ) {
+    return await int.reply( {
+      content: 'User must be attached to a valid voice channel.',
+      flags: MessageFlags.Ephemeral
+    } );
+  }
+
+  const track = LCARS47.MEDIA_PLAYER.getNowPlaying();
+  if ( track == null ) {
+    return await int.reply( { content: 'No media in queue.' } );
+  }
+
+  await int.deferReply();
+
+  const { lyrics, source } = await resolveLyrics( LCARS47, track );
+  if ( lyrics == null || lyrics.lines.length === 0 ) {
+    await int.editReply( `No lyrics could be located for __${ track.title }__.` );
+    return;
+  }
+
+  const artist = track.albumArtist ?? track.channelOrAlbumLabel;
+  const header = `**__Lyrics — ${ track.title }__**\n*${ artist }* · (via ${ source })`;
+  await sendPaginatedLyrics( int, header, lyrics );
+}
+
+/** Try Jellyfin first for library tracks, then lrclib.net for anything that
+ *  has no library lyrics (or isn't a Jellyfin track to begin with). */
+async function resolveLyrics(
+  LCARS47: LCARSClient,
+  track: Track
+): Promise<{ lyrics: LyricsResult | null; source: string }> {
+  if ( track.source === 'jellyfin' ) {
+    const provider = LCARS47.MEDIA_PLAYER.getProvider( 'jellyfin' );
+    if ( provider instanceof JellyfinProvider ) {
+      const jellyfinLyrics = await provider.getLyrics( track );
+      if ( jellyfinLyrics != null ) return { lyrics: jellyfinLyrics, source: 'Jellyfin' };
+    }
+  }
+
+  const fallback = await LrcLibClient.getLyrics( buildLyricsQuery( track ) );
+  return { lyrics: fallback, source: 'lrclib.net' };
+}
+
+/** Derive a clean { track, artist, album } query for lrclib from a Track.
+ *  The two sources encode metadata differently:
+ *    - Jellyfin: channelOrAlbumLabel is "Artist — Album"; title is the song.
+ *    - YouTube: title is usually "Artist - Song (Official Video)" and the
+ *      label is just the channel name, which is a poor artist key — so we
+ *      parse the artist out of the title instead and drop the channel. */
+function buildLyricsQuery( track: Track ): { trackName: string; artistName?: string; albumName?: string } {
+  if ( track.source === 'jellyfin' ) {
+    const [artist, album] = track.channelOrAlbumLabel.split( ' — ' );
+    return {
+      trackName: track.title,
+      artistName: track.albumArtist ?? artist?.trim(),
+      albumName: album?.trim()
+    };
+  }
+
+  // YouTube / other: strip "(Official Video)", "[Lyrics]", etc., then split
+  // an "Artist - Song" title on the first dash.
+  const cleaned = track.title
+    .replace( /\s*[([][^)\]]*[)\]]\s*/g, ' ' )
+    .replace( /\s+/g, ' ' )
+    .trim();
+  const parts = cleaned.split( /\s+[-–—]\s+/ );
+  if ( parts.length >= 2 ) {
+    return { artistName: parts[0].trim(), trackName: parts.slice( 1 ).join( ' - ' ).trim() };
+  }
+  // No parseable artist — search by the cleaned title alone.
+  return { trackName: cleaned };
+}
+
+/** Render the lyric body, split into pages that each stay under Discord's
+ *  message limit. Page 1 edits the deferred reply; the rest are follow-ups. */
+async function sendPaginatedLyrics (
+  int: ChatInputCommandInteraction,
+  header: string,
+  lyrics: LyricsResult
+): Promise<void> {
+  const body = lyrics.lines.map( l => l.text ).join( '\n' );
+
+  const chunks: string[] = [];
+  let current = '';
+  for ( const line of body.split( '\n' ) ) {
+    const next = `${ line }\n`;
+    if ( current.length + next.length > CHUNK_BUDGET ) {
+      chunks.push( current.trimEnd() );
+      current = '';
+    }
+    current += next;
+  }
+  if ( current.trim().length > 0 ) chunks.push( current.trimEnd() );
+  if ( chunks.length === 0 ) chunks.push( '(no lyric text)' );
+
+  for ( let i = 0; i < chunks.length; i += 1 ) {
+    const pageHeader = chunks.length > 1
+      ? `${ header } — page ${ i + 1 }/${ chunks.length }`
+      : header;
+    const content = `${ pageHeader }\n${ chunks[i] }`;
+    if ( i === 0 ) {
+      await int.editReply( { content } );
+    }
+    else {
+      await int.followUp( { content, flags: MessageFlags.SuppressEmbeds } );
+    }
+  }
+}
+
+function help (): string {
+  return 'Displays the lyrics for the currently playing song (Jellyfin library, with an lrclib.net fallback).';
+}
+
+export default {
+  name: 'Lyrics',
+  data,
+  execute,
+  help
+} satisfies Command;

--- a/Src/Commands/Active/search.ts
+++ b/Src/Commands/Active/search.ts
@@ -1,0 +1,364 @@
+// -- SEARCH --
+// Interactive song selector. Searches Jellyfin (falling back to YouTube when
+// the library has nothing) and lists up to 5 candidates — individual tracks
+// AND whole albums / playlists — each with a numbered button so the user can
+// queue a result directly. Picking a track queues that track; picking an
+// album/playlist expands it and queues every track. This closes the gap where
+// /jellyfin-search forced you to re-type a title into /play.
+//
+// Selection state can't ride inside a button customId (a Track is too big), so
+// results are stashed in a short-lived module cache keyed by the interaction
+// id; the button handler looks them up by that token, then resolves the chosen
+// entry into queueable tracks (expanding containers on demand).
+
+import {
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type ChatInputCommandInteraction,
+  type GuildMember,
+  type InteractionResponse,
+  type VoiceChannel,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  MessageFlags
+} from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+
+import { type LCARSClient } from '../../Subsystems/Auxiliary/LCARSClient.js';
+import Utility from '../../Subsystems/Utilities/SysUtils.js';
+import { type Command } from '../../Subsystems/Auxiliary/Interfaces/CommandInterface';
+import { convertSecondsToHMS } from '../../Subsystems/Utilities/MediaUtils.js';
+import { sourceLabel } from '../../Subsystems/MediaPlayer/TrackFormat.js';
+import { type Track } from '../../Subsystems/MediaPlayer/Interfaces/Track.js';
+import { JellyfinProvider } from '../../Subsystems/MediaPlayer/Providers/JellyfinProvider.js';
+import { YouTubeProvider } from '../../Subsystems/MediaPlayer/Providers/YouTubeProvider.js';
+import { type JellyfinItemKind } from '../../Subsystems/Jellyfin/Interfaces/JellyfinItem.js';
+
+const MAX_RESULTS = 5;           // Discord allows 5 buttons per action row.
+const JELLYFIN_SEARCH_LIMIT = 25; // Over-fetch so type filtering still yields hits.
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+type FilterType = 'track' | 'album' | 'playlist';
+
+// A selectable result. `resolve` turns it into the track(s) to queue when the
+// user clicks — for tracks that's the track itself; for containers it expands
+// the album/playlist (a network call) at click time.
+interface SearchEntry {
+  label: string;
+  resolve: ( requestedBy: GuildMember ) => Promise<Track[]>;
+}
+
+interface CachedSearch {
+  entries: SearchEntry[];
+  expiresAt: number;
+}
+
+// token (interaction id) -> results. Lazily purged on each new search.
+const resultCache = new Map<string, CachedSearch>();
+
+const data = new SlashCommandBuilder()
+  .setName( 'search' )
+  .setDescription( 'Search for music and pick a result to queue.' );
+
+data.addStringOption( o => o
+  .setName( 'query' )
+  .setDescription( 'Title / artist / album to look up.' )
+  .setRequired( true )
+);
+data.addStringOption( o => o
+  .setName( 'type' )
+  .setDescription( 'Limit results to a kind (default: everything).' )
+  .setRequired( false )
+  .addChoices(
+    { name: 'Track', value: 'track' },
+    { name: 'Album', value: 'album' },
+    { name: 'Playlist', value: 'playlist' }
+  )
+);
+data.addStringOption( o => o
+  .setName( 'source' )
+  .setDescription( 'Force a source (default: Jellyfin, then YouTube).' )
+  .setRequired( false )
+  .addChoices(
+    { name: 'Jellyfin', value: 'jellyfin' },
+    { name: 'YouTube', value: 'youtube' }
+  )
+);
+data.addStringOption( o => o
+  .setName( 'artist' )
+  .setDescription( 'Narrow results by artist.' )
+  .setRequired( false )
+);
+data.addStringOption( o => o
+  .setName( 'album' )
+  .setDescription( 'Narrow results by album.' )
+  .setRequired( false )
+);
+
+async function execute (
+  LCARS47: LCARSClient,
+  int: ChatInputCommandInteraction | AutocompleteInteraction
+): Promise<InteractionResponse | void> {
+  if ( int.isAutocomplete() ) return await int.respond([
+    { name: 'This command does not support autocomplete.', value: 'none' }
+  ]);
+
+  purgeExpired();
+
+  const type = int.options.getString( 'type' ) as FilterType | null;
+  const source = int.options.getString( 'source' ) as 'jellyfin' | 'youtube' | null;
+  const query = int.options.getString( 'query' ) ?? '';
+  const artist = int.options.getString( 'artist' ) ?? '';
+  const album = int.options.getString( 'album' ) ?? '';
+
+  await int.deferReply();
+
+  // Filters are extra search tokens — Jellyfin matches token-AND across
+  // title/artist/album, and YouTube benefits from the added context too.
+  const composedQuery = [query, artist, album].filter( s => s.trim() !== '' ).join( ' ' );
+
+  let entries: SearchEntry[] = [];
+  let usedSource: 'jellyfin' | 'youtube' | null = null;
+
+  // Jellyfin first (unless YouTube was forced).
+  if ( source !== 'youtube' ) {
+    const jellyfin = LCARS47.MEDIA_PLAYER.getProvider( 'jellyfin' );
+    if ( jellyfin instanceof JellyfinProvider && jellyfin.isEnabled() ) {
+      try {
+        entries = await searchJellyfin( jellyfin, composedQuery, type, LCARS47.MEMBER );
+        if ( entries.length > 0 ) usedSource = 'jellyfin';
+      }
+      catch ( err ) {
+        Utility.log( 'warn', `[SEARCH] Jellyfin search failed: ${ String( err ) }` );
+      }
+    }
+  }
+
+  // YouTube when forced, or as a fallback when Jellyfin had nothing.
+  if ( entries.length === 0 && source !== 'jellyfin' ) {
+    const youtube = LCARS47.MEDIA_PLAYER.getProvider( 'youtube' );
+    if ( youtube instanceof YouTubeProvider && youtube.isEnabled() ) {
+      try {
+        entries = await searchYouTube( youtube, composedQuery, LCARS47.MEMBER );
+        if ( entries.length > 0 ) usedSource = 'youtube';
+      }
+      catch ( err ) {
+        Utility.log( 'warn', `[SEARCH] YouTube search failed: ${ String( err ) }` );
+      }
+    }
+  }
+
+  if ( entries.length === 0 ) {
+    await int.editReply( 'No results found.' );
+    return;
+  }
+
+  // A single, unambiguous hit needs no menu — queue it straight away, provided
+  // the user is in a voice channel. If they aren't, fall through to the button
+  // so they can join and then click.
+  if ( entries.length === 1 ) {
+    const member = await fetchMember( LCARS47, int.user.id );
+    const voiceChannel = member?.voice?.channel ?? null;
+    if ( member != null && voiceChannel != null ) {
+      await queueEntry( LCARS47, int, entries[0], member, voiceChannel as VoiceChannel );
+      return;
+    }
+  }
+
+  const token = int.id;
+  resultCache.set( token, { entries, expiresAt: Date.now() + CACHE_TTL_MS } );
+
+  const lines = entries.map( ( e, i ) => `**${ i + 1 }.** ${ e.label }` );
+  const header = `**__Search Results (${ sourceLabel( usedSource ?? 'jellyfin' ) })__**`;
+  await int.editReply( {
+    content: `${ header }\n${ lines.join( '\n' ) }`,
+    components: buildButtons( token, entries.length )
+  } );
+}
+
+/** Build Jellyfin selectable entries — tracks and containers mixed. Over-fetch
+ *  then optionally filter to the requested type, so an album-only filter still
+ *  finds the album even if its track hits dominate the raw result order. */
+async function searchJellyfin(
+  provider: JellyfinProvider,
+  query: string,
+  type: FilterType | null,
+  searcher: GuildMember
+): Promise<SearchEntry[]> {
+  const items = await provider.searchSelectable( query, { limit: JELLYFIN_SEARCH_LIMIT } );
+  const filtered = type == null ? items : items.filter( i => matchesType( i.kind, type ) );
+
+  return filtered.slice( 0, MAX_RESULTS ).map( item => {
+    if ( item.kind === 'audio' ) {
+      const track = provider.toTrack( item, searcher );
+      return {
+        label: `**${ track.title }** — *${ track.channelOrAlbumLabel }* (${ convertSecondsToHMS( track.duration ) })`,
+        resolve: () => Promise.resolve( [track] )
+      };
+    }
+    const containerKind = item.kind === 'album' ? 'album' : 'playlist';
+    const icon = containerKind === 'album' ? '💿' : '🎵';
+    const artistSuffix = item.artist != null && item.artist !== '' ? ` — *${ item.artist }*` : '';
+    return {
+      label: `${ icon } **${ item.name }**${ artistSuffix } (${ containerKind })`,
+      resolve: ( rb: GuildMember ) => provider.resolveContainerTracks( item.id, containerKind, rb )
+    };
+  } );
+}
+
+/** Build YouTube selectable entries (tracks only). */
+async function searchYouTube(
+  provider: YouTubeProvider,
+  query: string,
+  searcher: GuildMember
+): Promise<SearchEntry[]> {
+  const tracks = await provider.searchMany( query, { requestedBy: searcher, limit: MAX_RESULTS } );
+  return tracks.map( track => ( {
+    label: `**${ track.title }** — *${ track.channelOrAlbumLabel }* (${ convertSecondsToHMS( track.duration ) })`,
+    resolve: () => Promise.resolve( [track] )
+  } ) );
+}
+
+function matchesType( kind: JellyfinItemKind, type: FilterType ): boolean {
+  if ( type === 'track' ) return kind === 'audio';
+  return kind === type; // 'album' | 'playlist'
+}
+
+/** Numbered pick buttons (one per result, max 5) on the first row, and a
+ *  Cancel button on its own row so it never competes for the 5-button slot
+ *  limit. Cancel lets the user bail out when no result fits. */
+function buildButtons( token: string, count: number ): ActionRowBuilder<ButtonBuilder>[] {
+  const pickRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    Array.from( { length: count }, ( _v, i ) => new ButtonBuilder()
+      .setCustomId( `search_pick_${ token }_${ i }` )
+      .setLabel( String( i + 1 ) )
+      .setStyle( ButtonStyle.Secondary )
+    )
+  );
+  const cancelRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId( `search_cancel_${ token }` )
+      .setLabel( 'Cancel' )
+      .setStyle( ButtonStyle.Danger )
+      .setEmoji( '✖️' )
+  );
+  return [pickRow, cancelRow];
+}
+
+async function handleButton (
+  LCARS47: LCARSClient,
+  int: ButtonInteraction
+): Promise<void> {
+  const parts = int.customId.split( '_' );
+  const action = parts[1]; // 'pick' | 'cancel'
+  const token = parts[2];
+  const index = Number( parts[3] );
+
+  // Cancel always works — clear the cache and strip the menu off the message.
+  if ( action === 'cancel' ) {
+    resultCache.delete( token );
+    await int.update( { content: 'Search cancelled.', components: [] } );
+    return;
+  }
+
+  const cached = resultCache.get( token );
+  if ( cached == null || cached.expiresAt < Date.now() ) {
+    resultCache.delete( token );
+    await int.reply( {
+      content: 'This search has expired — run `/search` again.',
+      flags: MessageFlags.Ephemeral
+    } );
+    return;
+  }
+
+  const entry = cached.entries[index];
+  if ( entry == null ) {
+    await int.reply( { content: 'That selection is no longer available.', flags: MessageFlags.Ephemeral } );
+    return;
+  }
+
+  // The clicker (not necessarily the original searcher) must be in a voice
+  // channel; they become the requester of whatever they queue.
+  const member = await fetchMember( LCARS47, int.user.id );
+  if ( member == null ) {
+    await int.reply( { content: 'No data could be found on your user.', flags: MessageFlags.Ephemeral } );
+    return;
+  }
+  if ( member.voice?.channel == null ) {
+    await int.reply( { content: 'You need to be in a voice channel first!', flags: MessageFlags.Ephemeral } );
+    return;
+  }
+
+  await queueEntry( LCARS47, int, entry, member, member.voice.channel as VoiceChannel );
+}
+
+/** Resolve a selected entry into tracks and queue them, replying with the
+ *  result. Shared by single-result auto-queue and button selection — both have
+ *  already deferred (or will), so this defers if needed and edits the reply.
+ *  Container entries expand over the network, hence the defer. */
+async function queueEntry(
+  LCARS47: LCARSClient,
+  int: ChatInputCommandInteraction | ButtonInteraction,
+  entry: SearchEntry,
+  member: GuildMember,
+  voiceChannel: VoiceChannel
+): Promise<void> {
+  if ( !int.deferred && !int.replied ) await int.deferReply();
+
+  let tracks: Track[];
+  try {
+    tracks = await entry.resolve( member );
+  }
+  catch ( err ) {
+    Utility.log( 'warn', `[SEARCH] Resolve failed: ${ String( err ) }` );
+    await int.editReply( 'Could not load that selection.' );
+    return;
+  }
+
+  if ( tracks.length === 0 ) {
+    await int.editReply( 'That selection had no playable tracks.' );
+    return;
+  }
+
+  const result = LCARS47.MEDIA_PLAYER.enqueueResolved( tracks, voiceChannel, member );
+  if ( !result.ok ) {
+    await int.editReply( 'Could not queue that selection.' );
+    return;
+  }
+
+  const reply = result.queuedCount > 1
+    ? `Queued **${ result.track.title }** + ${ result.queuedCount - 1 } more (${ sourceLabel( result.track.source ) })`
+    : `Queued **${ result.track.title }** (${ sourceLabel( result.track.source ) })`;
+  await int.editReply( `${ member.displayName } — ${ reply }` );
+}
+
+/** Fetch a guild member by user id, or null if the lookup fails. */
+async function fetchMember( LCARS47: LCARSClient, userId: string ): Promise<GuildMember | null> {
+  try {
+    return await LCARS47.PLDYN.members.fetch( userId );
+  }
+  catch {
+    return null;
+  }
+}
+
+/** Drop expired cache entries so the map doesn't grow unbounded. */
+function purgeExpired(): void {
+  const now = Date.now();
+  for ( const [token, entry] of resultCache ) {
+    if ( entry.expiresAt < now ) resultCache.delete( token );
+  }
+}
+
+function help (): string {
+  return 'Search Jellyfin (then YouTube) and pick a track, album, or playlist to queue. Filter by type, source, artist, or album.';
+}
+
+export default {
+  name: 'Search',
+  data,
+  execute,
+  handleButton,
+  help
+} satisfies Command;

--- a/Src/Subsystems/Jellyfin/Interfaces/LyricLine.ts
+++ b/Src/Subsystems/Jellyfin/Interfaces/LyricLine.ts
@@ -1,0 +1,18 @@
+// -- LyricLine --
+// Local DTOs for lyrics. Defined here so @jellyfin/sdk types stay contained
+// inside the JellyfinClient module — nothing else should import the SDK's
+// LyricDto / LyricLine shapes directly. These same DTOs are also produced by
+// the lrclib.net fallback (LrcLibClient) so the /lyrics command can render
+// either source uniformly.
+
+export interface LyricLine {
+  text: string;
+  /** Start offset in seconds when the source provides synced timing. */
+  startSeconds?: number;
+}
+
+export interface LyricsResult {
+  lines: LyricLine[];
+  /** True when at least one line carries timing (synced/karaoke source). */
+  synced: boolean;
+}

--- a/Src/Subsystems/Jellyfin/JellyfinClient.ts
+++ b/Src/Subsystems/Jellyfin/JellyfinClient.ts
@@ -17,8 +17,10 @@ import { Jellyfin, type Api } from '@jellyfin/sdk';
 import { BaseItemKind, ItemFields, ItemSortBy } from '@jellyfin/sdk/lib/generated-client';
 import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
 import { getSearchApi } from '@jellyfin/sdk/lib/utils/api/search-api';
+import { getLyricsApi } from '@jellyfin/sdk/lib/utils/api/lyrics-api';
 import Utility from '../Utilities/SysUtils.js';
 import { type JellyfinItem, type JellyfinItemKind } from './Interfaces/JellyfinItem.js';
+import { type LyricsResult } from './Interfaces/LyricLine.js';
 
 const CLIENT_INFO = {
   name: 'LCARS47 JClient',
@@ -236,6 +238,34 @@ export class JellyfinClient {
     }
 
     return items;
+  }
+
+  /** Fetch an item's lyrics from Jellyfin's dedicated Lyrics endpoint.
+   *  Lyrics are NOT a field on the item DTO — they live behind
+   *  GET /Audio/{itemId}/Lyrics and are only present when the library has an
+   *  .lrc / embedded lyric for the track. Returns null when the track has no
+   *  lyrics (404) or any error occurs, so callers can fall back cleanly. */
+  async getLyrics( itemId: string ): Promise<LyricsResult | null> {
+    const api = this.requireApi();
+
+    try {
+      const res = await getLyricsApi( api ).getLyrics( { itemId } );
+      const lines = res.data.Lyrics ?? [];
+      if ( lines.length === 0 ) return null;
+
+      return {
+        synced: lines.some( l => l.Start != null ),
+        lines: lines.map( l => ( {
+          text: l.Text ?? '',
+          // Jellyfin reports start time in ticks (10,000,000 per second).
+          startSeconds: l.Start != null ? l.Start / 10_000_000 : undefined
+        } ) )
+      };
+    }
+    catch ( err ) {
+      Utility.log( 'info', `[JELLYFIN] No lyrics for ${ itemId }: ${ String( err ) }` );
+      return null;
+    }
   }
 
   /** Build a server-side resized cover-art URL for an item. Jellyfin

--- a/Src/Subsystems/Lyrics/LrcLibClient.ts
+++ b/Src/Subsystems/Lyrics/LrcLibClient.ts
@@ -1,0 +1,109 @@
+// -- LrcLibClient --
+// Free, no-auth lyrics fallback (https://lrclib.net) used when Jellyfin has
+// no lyrics for a track — or when the now-playing track isn't a Jellyfin item
+// at all (e.g. YouTube). Returns the same LyricsResult DTO the JellyfinClient
+// produces so the /lyrics command renders either source uniformly.
+
+import Utility from '../Utilities/SysUtils.js';
+import { type LyricsResult } from '../Jellyfin/Interfaces/LyricLine.js';
+
+const API_BASE = 'https://lrclib.net/api';
+// lrclib's /get endpoint alone routinely takes ~3.5s and /search is slower;
+// the command has already deferred its reply, so allow generous headroom.
+const FETCH_TIMEOUT_MS = 10000;
+const USER_AGENT = 'LCARS47 (https://pldyn.net)';
+
+interface LrcLibRecord {
+  plainLyrics?: string | null;
+  syncedLyrics?: string | null;
+  instrumental?: boolean;
+}
+
+export interface LrcLibQuery {
+  trackName: string;
+  artistName?: string;
+  albumName?: string;
+}
+
+/** Strip `[mm:ss.xx]` timestamp tags from a synced (.lrc) lyric block,
+ *  leaving plain text lines. */
+function stripSyncedTags( synced: string ): string {
+  return synced
+    .split( /\r?\n/ )
+    .map( line => line.replace( /\[\d{1,2}:\d{2}(?:[.:]\d{1,3})?\]/g, '' ).trim() )
+    .join( '\n' )
+    .trim();
+}
+
+/** Map a raw lrclib record into a LyricsResult, preferring plain lyrics and
+ *  falling back to a de-timed synced block. Returns null for instrumentals
+ *  or records with no usable text. */
+function recordToResult( record: LrcLibRecord | null | undefined ): LyricsResult | null {
+  if ( record == null || record.instrumental === true ) return null;
+
+  let text = record.plainLyrics ?? '';
+  if ( text.trim() === '' && record.syncedLyrics != null ) {
+    text = stripSyncedTags( record.syncedLyrics );
+  }
+  if ( text.trim() === '' ) return null;
+
+  return {
+    synced: false,
+    lines: text.split( /\r?\n/ ).map( line => ( { text: line } ) )
+  };
+}
+
+async function fetchJson( url: string ): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout( () => controller.abort(), FETCH_TIMEOUT_MS );
+  try {
+    const res = await fetch( url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': USER_AGENT }
+    } );
+    if ( !res.ok ) return null;
+    return await res.json();
+  }
+  catch ( err ) {
+    Utility.log( 'warn', `[LRCLIB] Fetch failed: ${ String( err ) }` );
+    return null;
+  }
+  finally {
+    clearTimeout( timer );
+  }
+}
+
+/** Look up lyrics for a track. Tries the exact /get endpoint first (best
+ *  precision), then falls back to /search and takes the top hit. Returns null
+ *  when nothing usable is found. */
+export async function getLyrics( query: LrcLibQuery ): Promise<LyricsResult | null> {
+  const { trackName, artistName, albumName } = query;
+  if ( trackName.trim() === '' ) return null;
+
+  // Exact match: requires at least a track + artist to be meaningful.
+  if ( artistName != null && artistName.trim() !== '' ) {
+    const params = new URLSearchParams( {
+      track_name: trackName,
+      artist_name: artistName
+    } );
+    if ( albumName != null && albumName.trim() !== '' ) params.set( 'album_name', albumName );
+
+    const exact = await fetchJson( `${ API_BASE }/get?${ params.toString() }` );
+    const result = recordToResult( exact as LrcLibRecord );
+    if ( result != null ) return result;
+  }
+
+  // Fuzzy fallback: search and take the first record that yields lyrics.
+  const searchTerms = [trackName, artistName].filter( ( s ): s is string => s != null && s.trim() !== '' ).join( ' ' );
+  const searchParams = new URLSearchParams( { q: searchTerms } );
+  const hits = await fetchJson( `${ API_BASE }/search?${ searchParams.toString() }` );
+  if ( !Array.isArray( hits ) ) return null;
+
+  for ( const hit of hits as LrcLibRecord[] ) {
+    const result = recordToResult( hit );
+    if ( result != null ) return result;
+  }
+  return null;
+}
+
+export default { getLyrics };

--- a/Src/Subsystems/MediaPlayer/Interfaces/MediaProvider.ts
+++ b/Src/Subsystems/MediaPlayer/Interfaces/MediaProvider.ts
@@ -22,6 +22,11 @@ export interface SearchOptions {
    *  explicitly target a container (e.g. a YouTube /playlist?list=… URL)
    *  bypass this flag and always expand. */
   expandContainers?: boolean;
+  /** Explicit item kinds to search for. When set, providers should honour
+   *  this directly instead of deriving kinds from `expandContainers` — used
+   *  by /search's type filter (track / album / playlist). Jellyfin-specific;
+   *  other providers may ignore it. */
+  kinds?: ReadonlyArray<'audio' | 'album' | 'playlist'>;
 }
 
 export interface MediaProvider {

--- a/Src/Subsystems/MediaPlayer/MediaPlayerService.ts
+++ b/Src/Subsystems/MediaPlayer/MediaPlayerService.ts
@@ -124,14 +124,44 @@ export class MediaPlayerService {
       return { ok: false, reason: 'no-results' };
     }
 
-    const state = this.getOrCreateState( voiceChannel );
-    this.clearEmptyTimer( state );
-    state.tracks.push( ...resolved.tracks );
-
     Utility.log(
       'info',
       `[MEDIA-PLAYER] Queued ${ resolved.tracks.length } track(s) from ${ resolved.providerId }; head: ${ resolved.tracks[0].title }`
     );
+
+    return this.pushAndMaybePlay( resolved.tracks, voiceChannel );
+  }
+
+  /**
+   * Enqueue already-resolved track(s) directly, skipping the resolver. Used
+   * when a track has already been produced by an earlier search (e.g. the
+   * /search selector) and we just want to queue it. Stamps `requestedBy` onto
+   * each track so now-playing/queue attribution reflects who picked it.
+   */
+  enqueueResolved(
+    tracks: Track[],
+    voiceChannel: VoiceChannel,
+    requestedBy: GuildMember
+  ): EnqueueResult | EnqueueFailure {
+    if ( tracks.length === 0 ) {
+      return { ok: false, reason: 'no-results' };
+    }
+
+    const stamped = tracks.map( t => ( { ...t, requestedBy } ) );
+    Utility.log(
+      'info',
+      `[MEDIA-PLAYER] Queued ${ stamped.length } pre-resolved track(s); head: ${ stamped[0].title }`
+    );
+
+    return this.pushAndMaybePlay( stamped, voiceChannel );
+  }
+
+  /** Shared tail of enqueue/enqueueResolved: append to the queue and start
+   *  playback if idle. */
+  private pushAndMaybePlay( tracks: Track[], voiceChannel: VoiceChannel ): EnqueueResult {
+    const state = this.getOrCreateState( voiceChannel );
+    this.clearEmptyTimer( state );
+    state.tracks.push( ...tracks );
 
     let startedPlayback = false;
     if ( !state.isPlaying ) {
@@ -141,8 +171,8 @@ export class MediaPlayerService {
 
     return {
       ok: true,
-      track: resolved.tracks[0],
-      queuedCount: resolved.tracks.length,
+      track: tracks[0],
+      queuedCount: tracks.length,
       startedPlayback
     };
   }

--- a/Src/Subsystems/MediaPlayer/Providers/JellyfinProvider.ts
+++ b/Src/Subsystems/MediaPlayer/Providers/JellyfinProvider.ts
@@ -9,6 +9,7 @@ import { request as httpRequest } from 'http';
 import { PassThrough } from 'stream';
 import { StreamType } from '@discordjs/voice';
 import { type IncomingMessage } from 'http';
+import { type GuildMember } from 'discord.js';
 
 import {
   type MediaProvider,
@@ -49,9 +50,11 @@ export class JellyfinProvider implements MediaProvider {
     }
 
     const expandContainers = opts.expandContainers === true;
-    const kinds: ReadonlyArray<'audio' | 'album' | 'playlist'> = expandContainers
-      ? ['audio', 'album', 'playlist']
-      : ['audio'];
+    // An explicit `kinds` filter (from /search's type option) wins; otherwise
+    // derive kinds from expandContainers as before.
+    const kinds: ReadonlyArray<'audio' | 'album' | 'playlist'> = opts.kinds != null
+      ? opts.kinds
+      : ( expandContainers ? ['audio', 'album', 'playlist'] : ['audio'] );
 
     Utility.log(
       'info',
@@ -127,6 +130,39 @@ export class JellyfinProvider implements MediaProvider {
   async getLyrics( track: Track ): Promise<LyricsResult | null> {
     if ( !this.isEnabled() ) return null;
     return await this.client.getLyrics( track.id );
+  }
+
+  /** Search the library and return raw matched items — tracks AND containers
+   *  (albums / playlists), un-expanded — for the interactive /search selector.
+   *  Unlike search(), this does NOT expand containers or filter to audio, so
+   *  an album can be presented as its own selectable entry. */
+  async searchSelectable(
+    query: string,
+    opts: { limit?: number; kinds?: ReadonlyArray<'audio' | 'album' | 'playlist'> } = {}
+  ): Promise<JellyfinItem[]> {
+    if ( !this.isEnabled() ) return [];
+    const kinds = opts.kinds ?? ['audio', 'album', 'playlist'];
+    return await this.client.searchAudio( query, opts.limit ?? 25, kinds );
+  }
+
+  /** Map a single audio item to a queueable Track. Public wrapper over the
+   *  internal itemToTrack so the /search selector can build a Track from a
+   *  selectable item without reaching into Jellyfin internals. */
+  toTrack( item: JellyfinItem, requestedBy: GuildMember ): Track {
+    return this.itemToTrack( item, requestedBy );
+  }
+
+  /** Expand an album / playlist container into its queueable audio Tracks. */
+  async resolveContainerTracks(
+    containerId: string,
+    kind: 'album' | 'playlist',
+    requestedBy: GuildMember
+  ): Promise<Track[]> {
+    if ( !this.isEnabled() ) return [];
+    const children = await this.client.expandContainer( containerId, kind );
+    return children
+      .filter( c => c.kind === 'audio' )
+      .map( c => this.itemToTrack( c, requestedBy ) );
   }
 
   // ---- Internals ----

--- a/Src/Subsystems/MediaPlayer/Providers/JellyfinProvider.ts
+++ b/Src/Subsystems/MediaPlayer/Providers/JellyfinProvider.ts
@@ -19,6 +19,7 @@ import { type StreamHandle, type Track } from '../Interfaces/Track.js';
 import { LocalFileProvider, LocalUnreachableError } from './LocalFileProvider.js';
 import { type JellyfinClient } from '../../Jellyfin/JellyfinClient.js';
 import { type JellyfinItem } from '../../Jellyfin/Interfaces/JellyfinItem.js';
+import { type LyricsResult } from '../../Jellyfin/Interfaces/LyricLine.js';
 import { convertSecondsToHMS } from '../../Utilities/MediaUtils.js';
 import Utility from '../../Utilities/SysUtils.js';
 
@@ -118,6 +119,14 @@ export class JellyfinProvider implements MediaProvider {
     //    as the Jellyfin item id (set in itemToTrack).
     const url = this.client.buildStreamUrl( track.id );
     return await this.openHttpStream( url );
+  }
+
+  /** Fetch library lyrics for a Jellyfin-sourced track. Returns null when the
+   *  provider is offline or the track has no lyrics in the library — the
+   *  /lyrics command then falls back to an external source. */
+  async getLyrics( track: Track ): Promise<LyricsResult | null> {
+    if ( !this.isEnabled() ) return null;
+    return await this.client.getLyrics( track.id );
   }
 
   // ---- Internals ----

--- a/Src/Subsystems/MediaPlayer/Providers/YouTubeProvider.ts
+++ b/Src/Subsystems/MediaPlayer/Providers/YouTubeProvider.ts
@@ -84,6 +84,19 @@ export class YouTubeProvider implements MediaProvider {
     };
   }
 
+  /** Text-search YouTube and return up to `limit` candidate tracks. The
+   *  standard search() only yields the single best hit (it feeds /play's
+   *  auto-pick); the /search selector needs several to choose from. */
+  async searchMany( query: string, opts: SearchOptions ): Promise<Track[]> {
+    const results = await YouTube.search( query, {
+      type: 'video',
+      limit: opts.limit ?? 5
+    } );
+    return results
+      .map( v => this.videoToTrack( v, opts ) )
+      .filter( ( t ): t is Track => t != null );
+  }
+
   private async tryPlaylist( query: string, opts: SearchOptions ): Promise<ResolvedSearchResult | null> {
     Utility.log( 'info', `[YT-PROVIDER] Expanding YouTube playlist URL.` );
     let playlist: Playlist;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "lcars47",
   "version": "7.1.0-E.2",
+  "private": true,
   "description": "Official PlDyn Development Discord Bot",
   "exports": "./lcars47.js",
   "scripts": {
@@ -30,7 +31,7 @@
     "tag": "latest"
   },
   "author": "SkyeRangerDelta",
-  "license": "ISC",
+  "license": "SEE LICENSE IN README.md",
   "bugs": {
     "url": "https://github.com/SkyeRangerDelta/LCARS47/issues"
   },


### PR DESCRIPTION
This pull request introduces two major new features to the bot: an interactive music search command and a lyrics display command. Additionally, the `README.md` has been significantly rewritten to better describe the bot's capabilities, features, and intended audience.

**New Features:**

*Music System Enhancements*
- Added `/search` command for interactive music selection. Users can search Jellyfin (and fall back to YouTube), see up to 5 results (tracks, albums, or playlists), and queue selections directly via numbered buttons. The system caches search results for a short period to handle user interactions efficiently.
- Added `/lyrics` command to display lyrics for the currently playing track. The command fetches lyrics from the Jellyfin library when available, falling back to lrclib.net for other sources, and paginates long lyrics to fit Discord's message limits.

**Documentation Improvements:**

*README Overhaul*
- Rewrote `README.md` with a new banner, badges, and a detailed, themed description of the bot's features. The new documentation provides a clearer overview of the bot's music, AI, operations, astronomy, and crew service capabilities, and clarifies its source-available status and intended audience.